### PR TITLE
Added FunctionInliner from aref-macro

### DIFF
--- a/sincron-macros/shared/src/main/scala/org/sincron/macros/FunctionInliner.scala
+++ b/sincron-macros/shared/src/main/scala/org/sincron/macros/FunctionInliner.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://sincron.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sincron.macros
+
+import compat._
+
+class FunctionInliner[C <: Context](val c: C) {
+  import c.universe._
+
+  val ApplyMethod = TermName("apply")
+
+  def inlineParam(paramTermName: TermName, arg: Tree, body: Tree): Tree = new Transformer {
+    override def transform(tree: Tree): Tree = tree match {
+      case i@Ident(_) if i.name == paramTermName => arg
+
+      case _ => super.transform(tree)
+    }
+  }.transform(body)
+
+  def inline(function: Tree): Tree = new Transformer {
+    override def transform(tree: Tree): Tree = tree match {
+
+      case Apply(Function(params,body),args) =>
+        params.zip(args).foldLeft(body){ (b,paramArgs) =>
+          val (param, arg) = paramArgs
+          inlineParam(param.name, arg, b)
+        }
+
+      case Apply(Select(Function(params,body), ApplyMethod), args) =>
+        params.zip(args).foldLeft(body){ (b,paramArgs) =>
+          val (param, arg) = paramArgs
+          inlineParam(param.name, arg, b)
+        }
+
+      case _ => super.transform(tree)
+    }
+  }.transform(function)
+
+  def apply(function: Tree):Tree =
+    c.untypecheck(
+      inline(function)
+    )
+
+  def inlineAndReset[T](tree: Tree): c.Expr[T] = {
+    c.Expr[T](apply(tree))
+  }
+}

--- a/sincron-macros/shared/src/main/scala/org/sincron/macros/test/TestFunctionInlineMacros.scala
+++ b/sincron-macros/shared/src/main/scala/org/sincron/macros/test/TestFunctionInlineMacros.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://sincron.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sincron.macros.test
+
+import org.sincron.macros.FunctionInliner
+
+import scala.language.experimental.macros
+
+object TestFunctionInlineMacros {
+  import org.sincron.macros.compat._
+
+
+  def testInlineParamMacro(): Boolean = macro testInlineParamMacroImpl
+
+  def testInlineParamMacroImpl(c: Context)() = {
+    import c.universe._
+    val inliner = new FunctionInliner[c.type](c)
+    val Apply(Function(params, body), args) = q"((x:Int) => x + 1)(10)"
+    val actual = inliner.inlineParam(params.head.name,args.head, body)
+    val expected = q"10 + 1"
+    val result = actual equalsStructure expected
+    if(!result)
+      println(s"Expected ${expected} but got ${actual}")
+
+    q"$result"
+  }
+
+  def testInlineMacro(): Boolean = macro testInlineMacroImpl
+
+  def testInlineMacroImpl(c: Context)() = {
+    import c.universe._
+    val inliner = new FunctionInliner[c.type](c)
+
+    val result:Boolean = List({
+        val actual = inliner(q"((x:Int) => x + 1)(10)")
+        val expected = q"10 + 1"
+        val r = actual equalsStructure expected
+        if(!r)
+          println(s"Expected ${expected} but got ${actual}")
+        r
+      },
+      {
+        val actual = inliner(q"((x:Int) => x + 1).apply(10)")
+        val expected = q"10 + 1"
+        val r = actual equalsStructure expected
+        if(!r)
+          println(s"Expected ${expected} but got ${actual}")
+        r
+    }).forall(x => x)
+
+    q"$result"
+  }
+
+  def testInlineMultipleArgsMacro(): Boolean = macro testInlineMultipleArgsMacroImpl
+
+  def testInlineMultipleArgsMacroImpl(c: Context)() = {
+    import c.universe._
+    val inliner = new FunctionInliner[c.type](c)
+
+    val inlinedNoApplyFct = inliner(q"((x:Int, y:Int) => {val z = x + 1; y + z})(10, 20)")
+    val resultNoApply = inlinedNoApplyFct equalsStructure q"{val z = 10 + 1; 20 + z}"
+
+    val result:Boolean = List({
+        val actual = inliner(q"((x:Int, y:Int) => {val z = x + 1; y + z})(10, 20)")
+        val expected = q"{val z = 10 + 1; 20 + z}"
+        val r = actual equalsStructure expected
+        if(!r)
+          println(s"Expected ${expected} but got ${actual}")
+        r
+      },
+      {
+        val actual = inliner(q"((x:Int) => x + 1).apply(10)")
+        val expected = q"10 + 1"
+        val r = actual equalsStructure expected
+        if(!r)
+          println(s"Expected ${expected} but got ${actual}")
+        r
+      }
+    ).forall(x => x)
+
+    q"$result"
+  }
+}

--- a/sincron-macros/shared/src/main/scala/org/sincron/macros/test/TestInlineUtilMacros.scala
+++ b/sincron-macros/shared/src/main/scala/org/sincron/macros/test/TestInlineUtilMacros.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://sincron.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sincron.macros.test
+
+import org.sincron.macros.InlineUtil
+
+import scala.language.experimental.macros
+
+object TestInlineUtilMacros {
+  import org.sincron.macros.compat._
+
+
+
+  def testInlineMacro(): Boolean = macro testInlineMacroImpl
+
+  def testInlineMacroImpl(c: Context)() = {
+    import c.universe._
+    val inliner = new InlineUtil[c.type](c)
+
+    val result:Boolean = List({
+        val actual = inliner.inlineAndReset(q"((x:Int) => x + 1)(10)").tree
+        val expected = q"10 + 1"
+        val r = actual equalsStructure expected
+        if(!r)
+          println(s"Expected ${expected} but got ${actual}")
+        r
+      },
+      {
+        val actual = inliner.inlineAndReset(q"((x:Int) => x + 1).apply(10)").tree
+        val expected = q"10 + 1"
+        val r = actual equalsStructure expected
+        if(!r)
+          println(s"Expected ${expected} but got ${actual}")
+        r
+    }).forall(x => x)
+
+    q"$result"
+  }
+
+  def testInlineMultipleArgsMacro(): Boolean = macro testInlineMultipleArgsMacroImpl
+
+  def testInlineMultipleArgsMacroImpl(c: Context)() = {
+    import c.universe._
+    val inliner = new InlineUtil[c.type](c)
+
+    val inlinedNoApplyFct = inliner.inlineAndReset(q"((x:Int, y:Int) => {val z = x + 1; y + z})(10, 20)").tree
+    val resultNoApply = inlinedNoApplyFct equalsStructure q"{val z = 10 + 1; 20 + z}"
+
+    val result:Boolean = List({
+        val actual = inliner.inlineAndReset(q"((x:Int, y:Int) => {val z = x + 1; y + z})(10, 20)").tree
+        val expected = q"{val z = 10 + 1; 20 + z}"
+        val r = actual equalsStructure expected
+        if(!r)
+          println(s"Expected ${expected} but got ${actual}")
+        r
+      },
+      {
+        val actual = inliner.inlineAndReset(q"((x:Int) => x + 1).apply(10)").tree
+        val expected = q"10 + 1"
+        val r = actual equalsStructure expected
+        if(!r)
+          println(s"Expected ${expected} but got ${actual}")
+        r
+      }
+    ).forall(x => x)
+
+    q"$result"
+  }
+}

--- a/sincron-macros/shared/src/test/scala/org/sincron/macros/FunctionInlinerSuite.scala
+++ b/sincron-macros/shared/src/test/scala/org/sincron/macros/FunctionInlinerSuite.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://sincron.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sincron.macros
+
+import minitest.SimpleTestSuite
+import org.sincron.macros.test.TestFunctionInlineMacros
+
+
+object FunctionInlinerSuite extends SimpleTestSuite{
+
+  test("should inline a symbol in a block of code") {
+    assert(TestFunctionInlineMacros.testInlineParamMacro())
+  }
+
+  test("inline a function") {
+    assert(TestFunctionInlineMacros.testInlineMacro())
+  }
+
+  test("inline a function with 2 params") {
+    assert(TestFunctionInlineMacros.testInlineMultipleArgsMacro())
+  }
+}

--- a/sincron-macros/shared/src/test/scala/org/sincron/macros/InlineUtilSuite.scala
+++ b/sincron-macros/shared/src/test/scala/org/sincron/macros/InlineUtilSuite.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016 by its authors. Some rights reserved.
+ * See the project homepage at: https://sincron.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sincron.macros
+
+import minitest.SimpleTestSuite
+import org.sincron.macros.test.TestInlineUtilMacros
+
+
+object InlineUtilSuite extends SimpleTestSuite{
+
+  test("inline a function") {
+    assert(TestInlineUtilMacros.testInlineMacro())
+  }
+
+  test("inline a function with 2 params") {
+    assert(TestInlineUtilMacros.testInlineMultipleArgsMacro())
+  }
+}


### PR DESCRIPTION
- added tests for inlining macros
- made InlineUtil pass the test for multi params lambda, as the original implementation was failing to do so - I had to compare TermName and not Symbol
- not sure which inliner should we keep
- if I place the macro tests together with the suites, the compiler tells me they have to be in a different compilation unit
